### PR TITLE
Fix: Correct cannon orientation with vertical inversion

### DIFF
--- a/script.js
+++ b/script.js
@@ -44,7 +44,8 @@ function drawCannon() {
     if (!cannon) return;
     ctx.save();
     ctx.translate(cannon.x, cannon.y);
-    ctx.rotate(cannon.angle);
+    ctx.scale(1, -1);
+    ctx.rotate(-cannon.angle);
     ctx.fillStyle = CANNON_COLOR;
     // The cannon is a rectangle. By drawing it with a negative width,
     // it extends to the left of the pivot point, making it look like it's pointing left.


### PR DESCRIPTION
The cannon on the right was rendering with an incorrect orientation.

This commit corrects the issue by applying a vertical inversion to the cannon's drawing context using `ctx.scale(1, -1)`. The rotation angle is also negated to ensure it points correctly after the inversion. This aligns the cannon's visual representation with the projectile's trajectory.